### PR TITLE
only set input values if not empty

### DIFF
--- a/src/inputs.ts
+++ b/src/inputs.ts
@@ -85,7 +85,9 @@ export default class Inputs {
               newObj.key = keyParsed;
               break;
           }
-          this.config.set(newObj.key, newObj.value);
+          if (newObj.value) {
+            this.config.set(newObj.key, newObj.value);
+          }
           return newObj;
         }
         return undefined;


### PR DESCRIPTION
When a empty GitHub Action input is specified the default value e.g. `repo` will not be used. 
Instead the empty string will be used.

This PR will prevent assigning empty GHA input values to the config.

closes #171 