### PR TITLE
remove code-quote when vertical bar inside table

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ or use none, and instead use a `.ghadocs.json` file.
 | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | ----------------- | ------------ |
 | **`action`**                    | The absolute or relative path to the `action.yml` file to read in from.                                                  | `action.yml`      | **false**    |
 | **`readme`**                    | The absolute or relative path to the markdown output file that contains the formatting tokens within it.                 | `README.md`       | **false**    |
-| **`owner`**                     | The GitHub Action repository owner. i.e: bitflight-devops&#124;your-gh-username                                          |                   | **false**    |
+| **`owner`**                     | The GitHub Action repository owner. i.e: <code>bitflight-devops</code>&#124;<code>your-gh-username</code>                |                   | **false**    |
 | **`repo`**                      | The GitHub Action repository name. i.e: `github-action-readme-generator`                                                 |                   | **false**    |
 | **`save`**                      | Save the provided values in a `.ghadocs.json` file. This will update any existing `.ghadocs.json` file that is in place. |                   | **false**    |
 | **`pretty`**                    | Use `prettier` to pretty print the new README.md file                                                                    |                   | **false**    |

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ or use none, and instead use a `.ghadocs.json` file.
 | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | ----------------- | ------------ |
 | **`action`**                    | The absolute or relative path to the `action.yml` file to read in from.                                                  | `action.yml`      | **false**    |
 | **`readme`**                    | The absolute or relative path to the markdown output file that contains the formatting tokens within it.                 | `README.md`       | **false**    |
-| **`owner`**                     | The GitHub Action repository owner. i.e: `bitflight-devops`&#124;`your-gh-username`                                      |                   | **false**    |
+| **`owner`**                     | The GitHub Action repository owner. i.e: bitflight-devops&#124;your-gh-username                                          |                   | **false**    |
 | **`repo`**                      | The GitHub Action repository name. i.e: `github-action-readme-generator`                                                 |                   | **false**    |
 | **`save`**                      | Save the provided values in a `.ghadocs.json` file. This will update any existing `.ghadocs.json` file that is in place. |                   | **false**    |
 | **`pretty`**                    | Use `prettier` to pretty print the new README.md file                                                                    |                   | **false**    |

--- a/src/markdowner/index.ts
+++ b/src/markdowner/index.ts
@@ -45,7 +45,12 @@ export function ArrayOfArraysToMarkdownTable(providedTableContent: MarkdownArray
     const idx = i > 1 ? i - 1 : 0;
     const dataRow = tableContent[idx] as string[];
     for (const [j] of row.entries()) {
-      const content = dataRow[col]?.replace(/\|/g, '&#124;').replace(/\n/, '<br />') ?? '';
+      let content = dataRow[col]?.replace(/\n/, '<br />') ?? '';
+      if (content.includes('|')) {
+        content = content.replace(/\|/g, '&#124;');
+        content = content.replace(/`/g, '');
+      }
+
       if (j % 2 === 1) {
         if (i === 0) {
           (markdownArrays[i] as string[])[j] = ` **${content}** `;

--- a/src/markdowner/index.ts
+++ b/src/markdowner/index.ts
@@ -46,9 +46,21 @@ export function ArrayOfArraysToMarkdownTable(providedTableContent: MarkdownArray
     const dataRow = tableContent[idx] as string[];
     for (const [j] of row.entries()) {
       let content = dataRow[col]?.replace(/\n/, '<br />') ?? '';
+
+      // vertical pipe has to be escaped in markdown table
       if (content.includes('|')) {
         content = content.replace(/\|/g, '&#124;');
-        content = content.replace(/`/g, '');
+
+        // replace grave accents with <code> HTML element to resolve unicode character in markdown
+        let isClosingTag = false;
+        content.match(/`/g)?.forEach((match) => {
+          if (!isClosingTag) {
+            content = content.replace(match, '<code>');
+          } else {
+            content = content.replace(match, '</code>');
+          }
+          isClosingTag = !isClosingTag;
+        });
       }
 
       if (j % 2 === 1) {


### PR DESCRIPTION
As in #168 described the quote (grave accent: &#96;) should be removed that markdown interprets the vertical bar (`&#124;`) correctly.