### PR TITLE
ensure output table has only two columns

### DIFF
--- a/src/sections/update-outputs.ts
+++ b/src/sections/update-outputs.ts
@@ -9,7 +9,7 @@ export default function updateOutputs(token: string, inputs: Inputs): void {
   // Build the new README
   const content: string[] = [];
   const markdownArray: string[][] = [
-    ['**Output**', '**Description**', '**Default**', '**Required**'],
+    ['**Output**', '**Description**'],
   ];
   const vars = inputs.action.outputs;
   const tI = vars ? Object.keys(vars).length : 0;


### PR DESCRIPTION
As described in the metadata syntax for GitHub Actions outputs only has
two parameters:
- output
- description

see: [Metadata syntax for GitHub Actions: outputs for Docker container and JavaScript actions](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#outputs-for-docker-container-and-javascript-actions)