### PR TITLE
feat: only add description subject to table

### DIFF
--- a/src/sections/update-inputs.ts
+++ b/src/sections/update-inputs.ts
@@ -15,9 +15,21 @@ export default function updateInputs(token: string, inputs: Inputs): void {
     for (const key of Object.keys(vars)) {
       // eslint-disable-next-line security/detect-object-injection
       const values = vars[key];
+
+      let description = values?.description ?? '';
+
+      // Check if only first line should be added (only subject without body)
+      // eslint-disable-next-line no-useless-escape
+      const matches = description.match('(.*?)\n\n([\S\s]*)');
+      if (matches && matches.length >= 2) {
+        description = matches[1] || description;
+      }
+
+      description = description.trim().replace('\n', '<br />');
+
       const row: string[] = [
         `**\`${key.trim()}\`**`,
-        values?.description?.trim().replace('\n', '<br />') ?? '',
+        description,
         values?.default ? `\`${values.default}\`` : '',
         values?.required ? '**true**' : '__false__',
       ];

--- a/src/sections/update-outputs.ts
+++ b/src/sections/update-outputs.ts
@@ -20,7 +20,7 @@ export default function updateOutputs(token: string, inputs: Inputs): void {
       const values = vars[key];
       const row: string[] = [
         `\`${key.trim()}\``,
-        values?.description?.trim().replace('\n', ' ') ?? '',
+        values?.description?.trim().replace('\n', '<br />') ?? '',
       ];
       log.debug(JSON.stringify(row));
       markdownArray.push(row);

--- a/src/sections/update-outputs.ts
+++ b/src/sections/update-outputs.ts
@@ -18,9 +18,21 @@ export default function updateOutputs(token: string, inputs: Inputs): void {
     for (const key of Object.keys(vars)) {
       // eslint-disable-next-line security/detect-object-injection
       const values = vars[key];
+
+      let description = values?.description ?? '';
+
+      // Check if only first line should be added (only subject without body)
+      // eslint-disable-next-line no-useless-escape
+      const matches = description.match('(.*?)\n\n([\S\s]*)');
+      if (matches && matches.length >= 2) {
+        description = matches[1] || description;
+      }
+
+      description = description.trim().replace('\n', '<br />');
+
       const row: string[] = [
         `\`${key.trim()}\``,
-        values?.description?.trim().replace('\n', '<br />') ?? '',
+        description,
       ];
       log.debug(JSON.stringify(row));
       markdownArray.push(row);


### PR DESCRIPTION
Instead of adding the whole description to the table (inputs and outputs) only the first line should be added.

Similar to [best practice](https://github.com/conventional-commits/conventionalcommits.org/blob/9cdec378d26b7e451ae686011ec15057ddc6d0bd/content/v1.0.0/index.md?plain=1#L108) of git commit messages the description would benefit if the description will be split to subject and body.
In the first line the basic information will be placed (subject).
Followed after a blank line the body will follow.

The full description (subject and body) will then be available in the usage section only.
This will improve the readability of the table.

## Example

### Usage

<!-- start usage -->

```yaml
- uses: bitflight-devops/github-action-readme-generator@main
  with:
    # fist line
    #
    # second after space
    # and another one
    #
    # Default: action.yml
    multiline-with-space: ""

    # fist line
    # Default: action.yml
    singleline: ""

    # fist line
    # but no space after ln
    # Default: action.yml
    multiline-without-space: ""
```

<!-- end usage -->

### Inputs

<!-- start inputs -->

| **Input**                                | **Description**                      | **Default**             | **Required** |
| ---------------------------------------- | ------------------------------------ | ----------------------- | ------------ |
| **<code>multiline-with-space<code>**     | fist line                            | <code>action.yml</code> | **false**    |
| **<code>multiline-with-space</code>**    | fist line                            | <code>action.yml</code> | **false**    |
| **<code>singleline</code>**              | fist line                            | <code>action.yml</code> | **false**    |
| **<code>multiline-without-space</code>** | fist line<br />but no space after ln | <code>action.yml</code> | **false**    |

<!-- end inputs -->


## Diff

### Inputs

```diff
<!-- start inputs -->

| **Input**                                | **Description**                                              | **Default**             | **Required** |
| ---------------------------------------- | ------------------------------------------------------------ | ----------------------- | ------------ |
- | **<code>multiline-with-space<code>**   | fist line<br /><br />second after space<br />and another one | <code>action.yml</code> | **false**    |
+ | **<code>multiline-with-space</code>**  | fist line                                                    | <code>action.yml</code> | **false**    |
| **<code>singleline</code>**              | fist line                                                    | <code>action.yml</code> | **false**    |
| **<code>multiline-without-space</code>** | fist line<br />but no space after ln                         | <code>action.yml</code> | **false**    |

<!-- end inputs -->
```
