### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/github_actions_version_updater.yml
+++ b/.github/workflows/github_actions_version_updater.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.1.1
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.RELEASE_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,7 @@ jobs:
       - name: 'Report Coverage'
         if: always()
         continue-on-error: true
-        uses:  davelosert/vitest-coverage-report-action@v2
+        uses:  davelosert/vitest-coverage-report-action@v2.1.1
         with:
           json-summary-path: './out/coverage-summary.json'
           json-final-path: ./out/coverage-final.json


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.1.1](https://github.com/actions/checkout/releases/tag/v4.1.1)** on 2023-10-17T15:53:17Z
* **[davelosert/vitest-coverage-report-action](https://github.com/davelosert/vitest-coverage-report-action)** published a new release **[v2.1.1](https://github.com/davelosert/vitest-coverage-report-action/releases/tag/v2.1.1)** on 2023-07-30T18:10:47Z
