### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/assign.yml
+++ b/.github/workflows/assign.yml
@@ -6,7 +6,7 @@ jobs:
   auto-assign:
     runs-on: ubuntu-latest
     steps:
-      - uses: pozil/auto-assign-issue@v1.13.0
+      - uses: pozil/auto-assign-issue@v1.14.0
         if: github.actor != 'dependabot[bot]'
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,7 +52,7 @@ jobs:
       GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
       SKIP_PREFLIGHT_CHECK: true
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v4.1.4
         with:
           ref: ${{ inputs.sha }}
           token: ${{ secrets.RELEASE_TOKEN }}

--- a/.github/workflows/github_actions_version_updater.yml
+++ b/.github/workflows/github_actions_version_updater.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.1.4
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.RELEASE_TOKEN }}

--- a/.github/workflows/push_code_linting.yml
+++ b/.github/workflows/push_code_linting.yml
@@ -32,7 +32,7 @@ jobs:
       NPM_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
       GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v4.1.4
 
       - name: Install compatible Nodejs version
         id: setup-node
@@ -40,11 +40,11 @@ jobs:
         
       - name: Install Deps
         run: npm install
-      - uses: xt0rted/markdownlint-problem-matcher@v2
+      - uses: xt0rted/markdownlint-problem-matcher@v3.0.0
       - run: npm run lint:markdown
         continue-on-error: true
       - name: eslint
-        uses: reviewdog/action-eslint@v1.20.0
+        uses: reviewdog/action-eslint@v1.24.0
         with:
           reporter: github-pr-review # Change reporter.
           eslint_flags: src/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
     env:
       SKIP_PREFLIGHT_CHECK: true
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v4.1.4
         with:
           ref: ${{ github.head_ref || github.ref }}
 
@@ -51,7 +51,7 @@ jobs:
       - name: 'Report Coverage'
         if: always()
         continue-on-error: true
-        uses:  davelosert/vitest-coverage-report-action@v2
+        uses:  davelosert/vitest-coverage-report-action@v2.3.1
         with:
           json-summary-path: './out/coverage-summary.json'
           json-final-path: ./out/coverage-final.json


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[davelosert/vitest-coverage-report-action](https://github.com/davelosert/vitest-coverage-report-action)** published a new release **[v2.3.1](https://github.com/davelosert/vitest-coverage-report-action/releases/tag/v2.3.1)** on 2024-04-12T09:35:50Z
* **[reviewdog/action-eslint](https://github.com/reviewdog/action-eslint)** published a new release **[v1.24.0](https://github.com/reviewdog/action-eslint/releases/tag/v1.24.0)** on 2024-04-22T12:08:16Z
* **[pozil/auto-assign-issue](https://github.com/pozil/auto-assign-issue)** published a new release **[v1.14.0](https://github.com/pozil/auto-assign-issue/releases/tag/v1.14.0)** on 2024-04-04T07:51:37Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.1.4](https://github.com/actions/checkout/releases/tag/v4.1.4)** on 2024-04-24T13:33:24Z
* **[xt0rted/markdownlint-problem-matcher](https://github.com/xt0rted/markdownlint-problem-matcher)** published a new release **[v3.0.0](https://github.com/xt0rted/markdownlint-problem-matcher/releases/tag/v3.0.0)** on 2024-02-24T23:41:19Z
