### PR TITLE
fix: migrate biome.json config to schema 2.5.1

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.3.13/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.1/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",
@@ -54,13 +54,13 @@
       "!__tests__/payload.json"
     ],
     "rules": {
-      "recommended": true,
+      "preset": "recommended",
       "a11y": {
-        "recommended": true,
+        "preset": "recommended",
         "noNoninteractiveElementInteractions": "error"
       },
       "complexity": {
-        "recommended": true,
+        "preset": "recommended",
         "noForEach": "warn",
         "useLiteralKeys": "warn",
         "noExcessiveCognitiveComplexity": {
@@ -75,24 +75,21 @@
         "noUselessStringConcat": "error"
       },
       "correctness": {
-        "recommended": true,
+        "preset": "recommended",
         "noUnusedImports": "error",
         "noUnusedVariables": "error",
         "noUnusedFunctionParameters": "warn",
         "noUnusedPrivateClassMembers": "error",
         "useImportExtensions": "off",
-        "noUndeclaredDependencies": "warn"
+        "noUndeclaredDependencies": "warn",
+        "noDuplicateAttributes": "error"
       },
       "nursery": {
-        "recommended": true,
-        "noDuplicateAttributes": "error",
-        "noProto": "error",
-        "noScriptUrl": "error",
-        "useExplicitType": "error",
-        "useSpread": "error"
+        "preset": "recommended",
+        "useExplicitType": "error"
       },
       "performance": {
-        "recommended": true,
+        "preset": "recommended",
         "noAccumulatingSpread": "error",
         "noBarrelFile": "warn",
         "noDelete": "warn",
@@ -100,12 +97,13 @@
         "noReExportAll": "warn"
       },
       "security": {
-        "recommended": true,
+        "preset": "recommended",
         "noDangerouslySetInnerHtml": "error",
-        "noDangerouslySetInnerHtmlWithChildren": "error"
+        "noDangerouslySetInnerHtmlWithChildren": "error",
+        "noScriptUrl": "error"
       },
       "style": {
-        "recommended": true,
+        "preset": "recommended",
         "noNonNullAssertion": "warn",
         "noParameterAssign": "warn",
         "useDefaultParameterLast": "warn",
@@ -170,10 +168,11 @@
         "useSelfClosingElements": "error",
         "useShorthandAssign": "error",
         "useThrowNewError": "error",
-        "useThrowOnlyError": "error"
+        "useThrowOnlyError": "error",
+        "useSpreadOverApply": "error"
       },
       "suspicious": {
-        "recommended": true,
+        "preset": "recommended",
         "noAssignInExpressions": "warn",
         "noConsole": "warn",
         "noExplicitAny": "warn",
@@ -187,7 +186,8 @@
         "noUnsafeDeclarationMerging": "error",
         "useAwait": "error",
         "useErrorMessage": "error",
-        "useNumberToFixedDigitsArgument": "error"
+        "useNumberToFixedDigitsArgument": "error",
+        "noProto": "error"
       }
     }
   },


### PR DESCRIPTION
## Description

CI was failing on `main` (Code Linting Annotation workflow, and the Biome check step inside the unit-test jobs) because `biome.json` targeted schema `2.3.13` while the installed Biome CLI is `2.5.x`. Biome 2.5 renamed/relocated several rules that used to live under `nursery` (`noProto`, `noScriptUrl`, `noDuplicateAttributes`, `useSpread`) and deprecated the `recommended` key in favor of `preset`, so the stale config caused Biome to exit with configuration errors before linting even ran.

## Type of Change

- [x] Build/CI update

## Related Issues

- Fixes CI failures on `main` (Code Linting Annotation, unit test Biome step)

## Changes Made

- Ran `biome migrate --write` to update `biome.json`'s `$schema` to `2.5.1`
- Moved `noProto`, `noScriptUrl`, `noDuplicateAttributes` to their new rule groups (`suspicious`, `security`, `correctness`) and renamed `useSpread` to `useSpreadOverApply`
- Replaced deprecated `"recommended": true` keys with `"preset": "recommended"`

## Testing

- [x] All existing tests pass (`npx vitest run` — 156 passed)
- [x] `npm run build` succeeds
- [x] `biome lint ./src/ ./__tests__/` and `biome check ./src/ ./__tests__/` exit 0 (only pre-existing warnings/info, no errors)
- [x] `npm run lint:markdown` passes

## Checklist

- [x] My changes generate no new warnings or errors
- [x] New and existing unit tests pass locally with my changes


---
_Generated by [Claude Code](https://claude.ai/code/session_01AnAYBWpvu31tPfaHsywzvL)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code quality and linting settings to the latest schema version.
  * Refined the default rule set, including a few new checks and streamlined existing recommendations.
  * Kept the overall enforcement level consistent while aligning the configuration with newer standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->