### PR TITLE
fix(versioning): default disabled usage ref to main

### DIFF
--- a/__tests__/helpers.test.ts
+++ b/__tests__/helpers.test.ts
@@ -431,6 +431,25 @@ describe('helpers', () => {
         expect(result).toBe('main');
       });
 
+      it('should default to main when versioning is disabled without a branch', () => {
+        const inputs = createMockInputs({
+          'versioning:enabled': false,
+        });
+
+        const result = getCurrentVersionString(inputs);
+        expect(result).toBe('main');
+      });
+
+      it('should default to main when versioning is disabled with an empty branch', () => {
+        const inputs = createMockInputs({
+          'versioning:enabled': false,
+          'versioning:branch': '',
+        });
+
+        const result = getCurrentVersionString(inputs);
+        expect(result).toBe('main');
+      });
+
       it('should apply override even when not in explicit mode', () => {
         const inputs = createMockInputs({
           'versioning:enabled': true,

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -568,7 +568,8 @@ export function getCurrentVersionString(inputs: Inputs): string {
       versionString = `${prefix}${versionString}`;
     }
   } else {
-    versionString = inputs.config.get('versioning:branch') as string;
+    const configuredBranch = inputs.config.get('versioning:branch') as string | undefined;
+    versionString = undefinedOnEmpty(configuredBranch) ?? 'main';
   }
   log.debug(`version to use in generated example is ${versionString}`);
   return versionString;


### PR DESCRIPTION
## What changed

- default disabled-versioning usage references to `main` when no branch is configured
- treat an empty branch value as missing
- preserve explicitly configured branches
- add regression coverage for absent and empty branch values

## Root cause

The disabled-versioning branch returned `config.get('versioning:branch')` directly. Missing configuration therefore leaked JavaScript `undefined` into generated workflow syntax, while an empty CLI value produced an empty ref.

## Impact

Disabling versioning now produces the documented `owner/repo@main` fallback instead of an invalid `owner/repo@undefined` or empty ref.

## Validation

- failing-first regression tests reproduced both invalid outputs
- focused helpers suite: 46 tests passed
- full suite: 162 tests passed
- `npm run check`
- `npm run build`
- Markdown lint
- independent adversarial review: satisfied, no findings

Closes #637
