### PR TITLE
fix(versioning): preserve parsed falsy branch refs

### DIFF
--- a/__tests__/helpers.test.ts
+++ b/__tests__/helpers.test.ts
@@ -450,6 +450,22 @@ describe('helpers', () => {
         expect(result).toBe('main');
       });
 
+      it.each([
+        [false, 'false'],
+        [0, '0'],
+      ])(
+        'should preserve parsed falsy branch %j as %s when versioning is disabled',
+        (branch, expected) => {
+          const inputs = createMockInputs({
+            'versioning:enabled': false,
+            'versioning:branch': branch,
+          });
+
+          const result = getCurrentVersionString(inputs);
+          expect(result).toBe(expected);
+        },
+      );
+
       it('should apply override even when not in explicit mode', () => {
         const inputs = createMockInputs({
           'versioning:enabled': true,

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -568,8 +568,9 @@ export function getCurrentVersionString(inputs: Inputs): string {
       versionString = `${prefix}${versionString}`;
     }
   } else {
-    const configuredBranch = inputs.config.get('versioning:branch') as string | undefined;
-    versionString = undefinedOnEmpty(configuredBranch) ?? 'main';
+    const configuredBranch = inputs.config.get('versioning:branch');
+    versionString =
+      configuredBranch === undefined || configuredBranch === '' ? 'main' : String(configuredBranch);
   }
   log.debug(`version to use in generated example is ${versionString}`);
   return versionString;


### PR DESCRIPTION
Addresses the post-merge Codex review finding on #662.

nconf parses branch values such as `false` and `0` into boolean/number values. The disabled-versioning fallback now defaults only for an absent or empty branch and stringifies other configured values, preserving those valid Git refs.

Validation:
- Added regression cases for parsed `false` and `0`
- Focused helper suite: 48/48 passed
- Formatting, lint, type checks, and build passed
- Full suite: 163/164 passed; the sole failure is the pre-existing cross-filesystem `EXDEV` failure in `integration-issue-335.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed version string generation when versioning is disabled.
  * Configured branch values such as `false` and `0` are now preserved correctly instead of being treated as missing.
  * Empty or unavailable branch values continue to be handled appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->