### PR TITLE
fix(branding): generate SVG on first run

### DIFF
--- a/__tests__/update-branding.test.ts
+++ b/__tests__/update-branding.test.ts
@@ -1,0 +1,80 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { describe, expect, it, vi } from 'vite-plus/test';
+
+import { GHActionDocsConfig } from '../src/config.js';
+import type Inputs from '../src/inputs.js';
+import { generateImgMarkup } from '../src/sections/update-branding.js';
+import SVGEditor from '../src/svg-editor.mjs';
+
+describe('branding generation', () => {
+  it('generates the branding SVG on the first run', async () => {
+    const tempDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'ghadocs-branding-'));
+    const svgPath = path.join(tempDirectory, 'branding.svg');
+    const values = new Map<string, unknown>([['branding_svg_path', svgPath]]);
+    const inputs = {
+      action: { branding: { icon: 'book-open', color: 'yellow' } },
+      config: {
+        get: vi.fn((key: string) => values.get(key)),
+        set: vi.fn((key: string, value: unknown) => values.set(key, value)),
+      },
+    } as unknown as Inputs;
+    try {
+      generateImgMarkup(inputs);
+
+      await vi.waitFor(() => expect(fs.readFileSync(svgPath, 'utf8')).toContain('<svg'));
+      expect(inputs.config.set).toHaveBeenCalledWith('image_generated', 'book-openyellow');
+    } finally {
+      fs.rmSync(tempDirectory, { recursive: true, force: true });
+    }
+  });
+
+  it('retains the generated image hash when saving configuration', async () => {
+    const tempDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'ghadocs-config-'));
+    const configPath = path.join(tempDirectory, '.ghadocs.json');
+    const docsConfig = new GHActionDocsConfig();
+    const inputs = {
+      config: {
+        get: vi.fn(() => ({
+          branding_svg_path: '.github/ghadocs/branding.svg',
+          image_generated: 'book-openyellow',
+        })),
+      },
+    } as unknown as Inputs;
+
+    try {
+      docsConfig.loadInputs(inputs);
+      await docsConfig.save(configPath);
+
+      const savedConfig = JSON.parse(fs.readFileSync(configPath, 'utf8')) as Record<
+        string,
+        unknown
+      >;
+      expect(savedConfig.image_generated).toBe('book-openyellow');
+    } finally {
+      fs.rmSync(tempDirectory, { recursive: true, force: true });
+    }
+  });
+
+  it('does not regenerate branding when the saved hash still matches', () => {
+    const values = new Map<string, unknown>([
+      ['branding_svg_path', '.github/ghadocs/branding.svg'],
+      ['image_generated', 'book-openyellow'],
+    ]);
+    const inputs = {
+      action: { branding: { icon: 'book-open', color: 'yellow' } },
+      config: {
+        get: vi.fn((key: string) => values.get(key)),
+        set: vi.fn((key: string, value: unknown) => values.set(key, value)),
+      },
+    } as unknown as Inputs;
+    const generateSvgImage = vi.spyOn(SVGEditor.prototype, 'generateSvgImage');
+
+    generateImgMarkup(inputs);
+
+    expect(generateSvgImage).not.toHaveBeenCalled();
+    expect(inputs.config.set).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/update-branding.test.ts
+++ b/__tests__/update-branding.test.ts
@@ -59,8 +59,11 @@ describe('branding generation', () => {
   });
 
   it('does not regenerate branding when the saved hash still matches', () => {
+    const tempDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'ghadocs-branding-'));
+    const svgPath = path.join(tempDirectory, 'branding.svg');
+    fs.writeFileSync(svgPath, '<svg />');
     const values = new Map<string, unknown>([
-      ['branding_svg_path', '.github/ghadocs/branding.svg'],
+      ['branding_svg_path', svgPath],
       ['image_generated', 'book-openyellow'],
     ]);
     const inputs = {
@@ -72,9 +75,44 @@ describe('branding generation', () => {
     } as unknown as Inputs;
     const generateSvgImage = vi.spyOn(SVGEditor.prototype, 'generateSvgImage');
 
-    generateImgMarkup(inputs);
+    try {
+      generateImgMarkup(inputs);
 
-    expect(generateSvgImage).not.toHaveBeenCalled();
-    expect(inputs.config.set).not.toHaveBeenCalled();
+      expect(generateSvgImage).not.toHaveBeenCalled();
+      expect(inputs.config.set).not.toHaveBeenCalled();
+    } finally {
+      generateSvgImage.mockRestore();
+      fs.rmSync(tempDirectory, { recursive: true, force: true });
+    }
+  });
+
+  it('regenerates branding when the saved hash matches but the destination is missing', () => {
+    const values = new Map<string, unknown>([
+      ['branding_svg_path', '.github/ghadocs/moved-branding.svg'],
+      ['image_generated', 'book-openyellow'],
+    ]);
+    const inputs = {
+      action: { branding: { icon: 'book-open', color: 'yellow' } },
+      config: {
+        get: vi.fn((key: string) => values.get(key)),
+        set: vi.fn((key: string, value: unknown) => values.set(key, value)),
+      },
+    } as unknown as Inputs;
+    const generateSvgImage = vi
+      .spyOn(SVGEditor.prototype, 'generateSvgImage')
+      .mockImplementation(() => undefined);
+
+    try {
+      generateImgMarkup(inputs);
+
+      expect(generateSvgImage).toHaveBeenCalledWith(
+        '.github/ghadocs/moved-branding.svg',
+        'book-open',
+        'yellow',
+      );
+      expect(inputs.config.set).toHaveBeenCalledWith('image_generated', 'book-openyellow');
+    } finally {
+      generateSvgImage.mockRestore();
+    }
   });
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -46,6 +46,8 @@ export class GHActionDocsConfig {
 
   branding_svg_path?: string;
 
+  image_generated?: string;
+
   versioning?: Versioning;
 
   prettier?: boolean;
@@ -62,6 +64,7 @@ export class GHActionDocsConfig {
     this.title = config.title;
     this.paths = config.paths;
     this.branding_svg_path = config.branding_svg_path;
+    this.image_generated = config.image_generated;
     this.versioning = config.versioning;
     this.prettier = config.prettier;
   }

--- a/src/sections/update-branding.ts
+++ b/src/sections/update-branding.ts
@@ -1,3 +1,5 @@
+import { existsSync } from 'node:fs';
+
 import type { FeatherIconNames } from 'feather-icons';
 
 import {
@@ -123,7 +125,7 @@ export function generateImgMarkup(inputs: Inputs, width: string = '15%'): string
     log.info(`Generating action.yml branding image for ${iconName}`);
     const svg = inputs.config.get('image_generated') as Maybe<string>;
     const hash = `${iconName}${brandColor}`;
-    if (!svg || hash.localeCompare(svg) !== 0) {
+    if (!svg || hash.localeCompare(svg) !== 0 || !existsSync(svgPath)) {
       generateSvgImage(svgPath, iconName, brandColor);
       inputs.config.set('image_generated', hash);
     }

--- a/src/sections/update-branding.ts
+++ b/src/sections/update-branding.ts
@@ -123,7 +123,7 @@ export function generateImgMarkup(inputs: Inputs, width: string = '15%'): string
     log.info(`Generating action.yml branding image for ${iconName}`);
     const svg = inputs.config.get('image_generated') as Maybe<string>;
     const hash = `${iconName}${brandColor}`;
-    if (svg && hash.localeCompare(svg) !== 0) {
+    if (!svg || hash.localeCompare(svg) !== 0) {
       generateSvgImage(svgPath, iconName, brandColor);
       inputs.config.set('image_generated', hash);
     }


### PR DESCRIPTION
Closes #638.

Generate the configured branding SVG when no prior `image_generated` hash exists, while retaining the existing skip when the saved icon/color hash still matches. Persist `image_generated` through `GHActionDocsConfig` so `--save` makes that optimization effective on subsequent runs.

Validation:
- First-run test writes and reads a real SVG
- Save test writes `.ghadocs.json` and verifies the persisted hash
- Matching-hash test verifies SVG regeneration is skipped
- Focused tests: 3/3 passed
- Formatting, lint, type checks, and build passed
- Full suite: 163/164 passed; the sole failure is the pre-existing cross-filesystem `EXDEV` failure in `integration-issue-335.test.ts`
- Independent checker: satisfied