### PR TITLE
fix(cli): parse sections as an array

### DIFF
--- a/__tests__/inputs.test.ts
+++ b/__tests__/inputs.test.ts
@@ -137,6 +137,28 @@ describe('inputs', () => {
       expect(result).toBeInstanceOf(Provider);
     });
 
+    test('loadConfig parses one CLI section as an array', ({ task }) => {
+      const originalArgv = process.argv;
+      process.argv = ['node', 'script', '--sections=usage'];
+      try {
+        const config = loadConfig(new LogTask(task.name), new Provider());
+        expect(config.get('sections')).toEqual(['usage']);
+      } finally {
+        process.argv = originalArgv;
+      }
+    });
+
+    test('loadConfig parses repeated CLI sections as an array', ({ task }) => {
+      const originalArgv = process.argv;
+      process.argv = ['node', 'script', '--sections=usage', '--sections=inputs'];
+      try {
+        const config = loadConfig(new LogTask(task.name), new Provider());
+        expect(config.get('sections')).toEqual(['usage', 'inputs']);
+      } finally {
+        process.argv = originalArgv;
+      }
+    });
+
     describe('loadGithubContext', () => {
       beforeEach(() => {
         // const { statSync, readFileSync, existsSync } =

--- a/src/inputs.ts
+++ b/src/inputs.ts
@@ -264,6 +264,17 @@ argvOptions[ConfigKeys.DebugConfig] = {
 };
 
 /**
+ * README sections option configuration.
+ * Declaring this as an array keeps a single `--sections=usage` value consistent
+ * with the array shape used by `.ghadocs.json` and repeated CLI arguments.
+ */
+argvOptions.sections = {
+  alias: 'sections',
+  describe: 'Only generate the named README section (repeat for multiple sections)',
+  type: 'array',
+};
+
+/**
  * Configuration inputs from the github action don't
  * all match the input names when running on cli.
  * This maps the action inputs to the cli.


### PR DESCRIPTION
Closes #639.

Declare `sections` as an array-valued CLI option so a single `--sections=usage` has the same shape as repeated CLI flags and the existing `.ghadocs.json` array.

Validation:
- Failing-first proof: the undeclared single flag resolved to the string `usage`
- Single CLI section resolves to `["usage"]`
- Repeated CLI sections resolve to `["usage", "inputs"]`
- Existing JSON-array behavior is unchanged
- Focused tests: 21/21 passed
- Formatting, lint, type checks, and build passed
- Full suite: 163/164 passed; the sole failure is the pre-existing cross-filesystem `EXDEV` failure in `integration-issue-335.test.ts`
- Independent checker: satisfied

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting specific README sections through the `--sections` command-line option.
  * Multiple `--sections` options can be provided and are processed in the order specified.

* **Tests**
  * Added coverage for single and repeated section-selection options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->