### PR TITLE
fix(markdown): escape backslashes in table cells

### DIFF
--- a/__tests__/markdowner.test.ts
+++ b/__tests__/markdowner.test.ts
@@ -20,8 +20,11 @@ test('padString pads text to width with spaces', () => {
   expect(padString('Hello', 8, 3)).toBe('   Hello   ');
 });
 
-test('markdownEscapeTableCell escapes newlines and pipes', () => {
+test('markdownEscapeTableCell escapes newlines, backslashes, and pipes', () => {
   expect(markdownEscapeTableCell('Hello\nWorld|Foo')).toBe('Hello<br />World\\|Foo');
+  expect(markdownEscapeTableCell(String.raw`Backslash-pipe \|`)).toBe(
+    String.raw`Backslash-pipe \\\|`,
+  );
 });
 
 test('markdownEscapeInlineCode escapes inline code', () => {
@@ -56,4 +59,16 @@ test('ArrayOfArraysToMarkdownTable converts array to markdown table', () => {
 `;
 
   expect(ArrayOfArraysToMarkdownTable(testArray)).toBe(expected);
+});
+
+test('ArrayOfArraysToMarkdownTable preserves a literal backslash before a pipe', () => {
+  const table = ArrayOfArraysToMarkdownTable([
+    ['Input', 'Description', 'Default', 'Required'],
+    ['mode', String.raw`Accepts a literal backslash-pipe \| in the text.`, 'a', 'false'],
+  ]);
+
+  expect(table).toContain(String.raw`Accepts a literal backslash-pipe \\\| in the text.`);
+  expect(table).toContain(
+    String.raw`| mode | Accepts a literal backslash-pipe \\\| in the text. | a | false |`,
+  );
 });

--- a/__tests__/markdowner.test.ts
+++ b/__tests__/markdowner.test.ts
@@ -25,6 +25,9 @@ test('markdownEscapeTableCell escapes newlines, backslashes, and pipes', () => {
   expect(markdownEscapeTableCell(String.raw`Backslash-pipe \|`)).toBe(
     String.raw`Backslash-pipe \\\|`,
   );
+  expect(markdownEscapeTableCell(String.raw`Markdown escapes \*literal\*`)).toBe(
+    String.raw`Markdown escapes \*literal\*`,
+  );
 });
 
 test('markdownEscapeInlineCode escapes inline code', () => {

--- a/src/markdowner/index.ts
+++ b/src/markdowner/index.ts
@@ -23,7 +23,7 @@ export function padString(text: string, width: number, paddingStart: number): st
  * @returns The escaped text.
  */
 export function markdownEscapeTableCell(text: string): string {
-  return text.replaceAll('\n', '<br />').replaceAll('|', '\\|');
+  return text.replaceAll('\n', '<br />').replaceAll('\\', '\\\\').replaceAll('|', '\\|');
 }
 
 /**

--- a/src/markdowner/index.ts
+++ b/src/markdowner/index.ts
@@ -23,7 +23,10 @@ export function padString(text: string, width: number, paddingStart: number): st
  * @returns The escaped text.
  */
 export function markdownEscapeTableCell(text: string): string {
-  return text.replaceAll('\n', '<br />').replaceAll('\\', '\\\\').replaceAll('|', '\\|');
+  return text
+    .replaceAll('\n', '<br />')
+    .replaceAll(/\\+(?=\|)/g, (slashes) => slashes.repeat(2))
+    .replaceAll('|', '\\|');
 }
 
 /**


### PR DESCRIPTION
Closes #672

## Assessment

A source backslash immediately before a pipe is currently emitted as `\\|`. Markdown interprets that as a literal backslash followed by a live table delimiter, shifting subsequent cells. This is a user-visible README corruption, so fixing it improves correctness for action descriptions containing shell paths or escaped pipes.

## Change

- Escape source backslashes before escaping table delimiters.
- Add direct helper and generated-table regressions for `\\|` input.

## Validation

- Focused markdowner suite: 8/8 passed.
- Full suite: 171/171 passed.
- Type-aware check and formatting passed.
- Build passed.
- Markdown lint passed.
- Independent adversarial render check confirmed ordinary pipes, one or two source backslashes before pipes, and slash-only content all retain exactly three table cells and preserve literal content.

## Integration note

PR #634 contains a separate README contract verifier. When it rebases after this fix, its table-cell normalisation should account for doubled source backslashes.