### PR TITLE
fix(integration): validate every generated section

### DIFF
--- a/__tests__/integration-readme-contract.test.ts
+++ b/__tests__/integration-readme-contract.test.ts
@@ -16,6 +16,7 @@
  * fixture rather than hardcoded, so adding an input to the fixture extends the
  * assertions with it.
  */
+import { spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -26,6 +27,8 @@ import YAML from 'yaml';
 import Inputs from '../src/inputs.js';
 import LogTask from '../src/logtask/index.js';
 import { ReadmeGenerator } from '../src/readme-generator.js';
+
+const VERIFIER_SCRIPT = path.resolve('scripts/verify-readme-contract.mjs');
 
 /** Inputs and outputs the generated README has to account for, one per shape. */
 const ACTION_YML = `name: Contract Test Action
@@ -363,6 +366,46 @@ describe('README generation contract', () => {
       const third = await generate();
 
       expect(third).toBe(second);
+    });
+
+    it('passes the exact verifier after contents and badges converge', async () => {
+      const originalReadme = `${README_WITH_MARKERS}\n## First Heading\n\n### Child Heading\n`;
+      const originalReadmePath = path.join(tempDir, 'README.original.md');
+      fs.writeFileSync(readmePath, originalReadme);
+      fs.writeFileSync(originalReadmePath, originalReadme);
+      fs.writeFileSync(
+        path.join(tempDir, '.ghadocs.json'),
+        JSON.stringify({
+          owner: 'contract-owner',
+          repo: 'contract-repo',
+          title_prefix: 'GitHub Action: ',
+          branding_svg_path: '.github/ghadocs/branding.svg',
+          branding_as_title_prefix: false,
+          versioning: { badge: true },
+        }),
+      );
+
+      await generate();
+      await generate();
+      const finalReadme = await generate();
+
+      expect(sectionBody(finalReadme, 'contents')).toContain('[First Heading](#first-heading)');
+      expect(sectionBody(finalReadme, 'badges')).toContain(
+        'img.shields.io/github/v/release/contract-owner/contract-repo',
+      );
+      const verification = spawnSync(
+        process.execPath,
+        [
+          VERIFIER_SCRIPT,
+          actionPath,
+          readmePath,
+          originalReadmePath,
+          'contract-owner/contract-repo',
+        ],
+        { cwd: tempDir, encoding: 'utf8' },
+      );
+      expect(verification.status, `${verification.stdout}\n${verification.stderr}`).toBe(0);
+      expect(verification.stdout).toContain('All contract checks passed');
     });
   });
 });

--- a/__tests__/update-contents.test.ts
+++ b/__tests__/update-contents.test.ts
@@ -202,6 +202,32 @@ echo "test"
       const lines = result[sectionToken].split('\n').filter((l) => l.startsWith('-'));
       expect(lines).toHaveLength(2);
     });
+
+    it('should ignore headers inside tilde and longer backtick fences', () => {
+      vi.mocked(mockInputs.readmeEditor.getReadmeContent).mockReturnValue(`
+## Before Code
+
+~~~markdown
+## Hidden By Tildes
+~~~
+
+\`\`\`\`markdown
+## Hidden By Four Backticks
+\`\`\`
+## Still Hidden By Four Backticks
+\`\`\`\`
+
+## After Code
+`);
+
+      const result = updateContents(sectionToken, mockInputs);
+
+      expect(result[sectionToken]).toContain('- [Before Code](#before-code)');
+      expect(result[sectionToken]).toContain('- [After Code](#after-code)');
+      expect(result[sectionToken]).not.toContain('Hidden By Tildes');
+      expect(result[sectionToken]).not.toContain('Hidden By Four Backticks');
+      expect(result[sectionToken]).not.toContain('Still Hidden By Four Backticks');
+    });
   });
 
   describe('nested headers and indentation', () => {

--- a/__tests__/verify-readme-contract.test.ts
+++ b/__tests__/verify-readme-contract.test.ts
@@ -60,6 +60,13 @@ const README =
  */
 const unformatted = (readme: string): string => readme.replace('**false**', '__false__');
 
+const BADGES =
+  '<a href="https://github.com/owner/repo/releases/latest"><img src="https://img.shields.io/github/v/release/owner/repo?display_name=tag&amp;sort=semver&amp;logo=github&amp;style=flat-square" alt="Release by tag" /></a>' +
+  '<a href="https://github.com/owner/repo/releases/latest"><img src="https://img.shields.io/github/release-date/owner/repo?display_name=tag&amp;sort=semver&amp;logo=github&amp;style=flat-square" alt="Release by date" /></a>' +
+  '<img src="https://img.shields.io/github/last-commit/owner/repo?logo=github&amp;style=flat-square" alt="Commit" />' +
+  '<a href="https://github.com/owner/repo/issues"><img src="https://img.shields.io/github/issues/owner/repo?logo=github&amp;style=flat-square" alt="Open Issues" /></a>' +
+  '<img src="https://img.shields.io/github/downloads/owner/repo/total?logo=github&amp;style=flat-square" alt="Downloads" />';
+
 const verify = (
   readme = README,
   action = ACTION,
@@ -455,6 +462,15 @@ describe('README contract verifier regressions', () => {
     ).toThrow();
   });
 
+  it.each([
+    ['name', '  name: stale\n'],
+    ['run', '  run: echo stale\n'],
+    ['env', '  env:\n    STALE: true\n'],
+  ])('rejects an extra %s property in the generated usage step', (_name, property) => {
+    const readme = README.replace('  with:\n', `${property}  with:\n`);
+    expect(() => verify(readme)).toThrow();
+  });
+
   it.each(['before', 'after'])('rejects stale content %s the generated usage fence', (position) => {
     const replacement =
       position === 'before'
@@ -616,6 +632,129 @@ describe('README contract verifier regressions', () => {
     const row = String.raw`| <b><code>path</code></b> | A \\\| B |  | **false** |`;
     const readme = README.replace('<!-- end inputs -->', `${row}\n<!-- end inputs -->`);
     expect(() => verify(readme)).toThrow();
+  });
+
+  it.each([
+    ['before', 'inputs'],
+    ['after', 'inputs'],
+    ['before', 'outputs'],
+    ['after', 'outputs'],
+  ])('rejects stale prose %s the nonempty %s table', (position, name) => {
+    const outputAction = ACTION.replace(
+      'runs:',
+      'outputs:\n  result:\n    description: Result\n    value: ${{ steps.result.outputs.value }}\nruns:',
+    );
+    const outputTable = [
+      '| **Output** | **Description** | **Value** |',
+      '|---|---|---|',
+      '| <b><code>result</code></b> | Result | <code>${{ steps.result.outputs.value }}</code> |',
+    ].join('\n');
+    const baseline =
+      name === 'outputs'
+        ? README.replace(
+            '<!-- start outputs -->\n<!-- end outputs -->',
+            `<!-- start outputs -->\n${outputTable}\n<!-- end outputs -->`,
+          )
+        : README;
+    const action = name === 'outputs' ? outputAction : ACTION;
+    const readme =
+      position === 'before'
+        ? baseline.replace(`<!-- start ${name} -->\n`, `<!-- start ${name} -->\nstale prose\n`)
+        : baseline.replace(`\n<!-- end ${name} -->`, `\nstale prose\n<!-- end ${name} -->`);
+
+    expect(() => verify(readme, action)).toThrow();
+  });
+
+  it('validates the complete generated contents projection', () => {
+    const contents = [
+      '## Table of Contents',
+      '',
+      '- [First Heading](#first-heading)',
+      '  - [Child Heading](#child-heading)',
+      '- [First Heading](#first-heading-1)',
+    ].join('\n');
+    const readme = `${README}<!-- start contents -->\n${contents}\n<!-- end contents -->\n## First Heading\n### Child Heading\n## First Heading\n\n\`\`\`markdown\n## Fenced Heading\n\`\`\`\n`;
+
+    expect(verify(readme)).toContain('All contract checks passed');
+    expect(() => verify(readme.replace('#first-heading-1', '#stale'))).toThrow();
+    expect(() => verify(readme.replace('- [First Heading](#first-heading)\n', ''))).toThrow();
+    expect(() =>
+      verify(readme.replace('\n<!-- end contents -->', '\nstale prose\n<!-- end contents -->')),
+    ).toThrow();
+  });
+
+  it('requires an empty contents projection when the README has no eligible headings', () => {
+    const readme = `${README}<!-- start contents -->\n<!-- end contents -->\n`;
+    expect(verify(readme)).toContain('All contract checks passed');
+    expect(() =>
+      verify(readme.replace('<!-- start contents -->', '<!-- start contents -->\nstale entry')),
+    ).toThrow();
+  });
+
+  it('validates the complete enabled badges projection', () => {
+    const readme = `${README}<!-- start badges -->\n${BADGES}\n<!-- end badges -->\n`;
+    const config = {
+      title_prefix: 'GitHub Action: ',
+      branding_as_title_prefix: false,
+      owner: 'owner',
+      repo: 'repo',
+      versioning: { badge: true },
+    };
+
+    expect(verify(readme, ACTION, config)).toContain('All contract checks passed');
+    expect(() => verify(readme.replace('Release by tag', 'Stale tag'), ACTION, config)).toThrow();
+    expect(() =>
+      verify(
+        readme.replace('\n<!-- end badges -->', '\nstale prose\n<!-- end badges -->'),
+        ACTION,
+        config,
+      ),
+    ).toThrow();
+  });
+
+  it('preserves opted-in badges when generation is disabled', () => {
+    const original = `${README}<!-- start badges -->\nuser-owned badge\n<!-- end badges -->\n`;
+    const config = {
+      title_prefix: 'GitHub Action: ',
+      branding_as_title_prefix: false,
+      versioning: { badge: false },
+    };
+
+    expect(verify(original, ACTION, config, '.', original)).toContain('All contract checks passed');
+    expect(() =>
+      verify(original.replace('user-owned badge', 'changed badge'), ACTION, config, '.', original),
+    ).toThrow();
+    expect(
+      verify(
+        original.replace('<!-- start badges -->\n', '<!-- start badges -->\n\n'),
+        ACTION,
+        config,
+        '.',
+        original,
+      ),
+    ).toContain('All contract checks passed');
+  });
+
+  it('preserves disabled badges byte-for-byte when prettier is off', () => {
+    const base = unformatted(README.replace('**bold**', '__bold__'));
+    const original = `${base}<!-- start badges -->\n__user badge__\n<!-- end badges -->\n`;
+    const config = {
+      title_prefix: 'GitHub Action: ',
+      branding_as_title_prefix: false,
+      prettier: false,
+      versioning: { badge: false },
+    };
+
+    expect(verify(original, ACTION, config, '.', original)).toContain('All contract checks passed');
+    expect(() =>
+      verify(
+        original.replace('<!-- start badges -->\n', '<!-- start badges -->\n\n'),
+        ACTION,
+        config,
+        '.',
+        original,
+      ),
+    ).toThrow();
   });
 
   it('validates output values and declaration order', () => {

--- a/__tests__/verify-readme-contract.test.ts
+++ b/__tests__/verify-readme-contract.test.ts
@@ -683,6 +683,23 @@ describe('README contract verifier regressions', () => {
     ).toThrow();
   });
 
+  it('ignores headings inside tilde and longer backtick fences', () => {
+    const contents = ['## Table of Contents', '', '- [Visible Heading](#visible-heading)'].join(
+      '\n',
+    );
+    const readme = `${README}<!-- start contents -->\n${contents}\n<!-- end contents -->\n## Visible Heading\n\n~~~markdown\n## Hidden By Tildes\n~~~\n\n\`\`\`\`markdown\n## Hidden By Four Backticks\n\`\`\`\n## Still Hidden By Four Backticks\n\`\`\`\`\n`;
+
+    expect(verify(readme)).toContain('All contract checks passed');
+    expect(() =>
+      verify(
+        readme.replace(
+          '- [Visible Heading](#visible-heading)',
+          '- [Visible Heading](#visible-heading)\n- [Hidden By Tildes](#hidden-by-tildes)',
+        ),
+      ),
+    ).toThrow();
+  });
+
   it('requires an empty contents projection when the README has no eligible headings', () => {
     const readme = `${README}<!-- start contents -->\n<!-- end contents -->\n`;
     expect(verify(readme)).toContain('All contract checks passed');

--- a/scripts/verify-readme-contract.mjs
+++ b/scripts/verify-readme-contract.mjs
@@ -675,13 +675,21 @@ for (const name of ['title', 'description', 'branding']) {
 /** Mirrors the contents projection in `src/sections/update-contents.ts`. */
 const expectedContents = async () => {
   const headers = [];
-  let inCodeBlock = false;
+  let codeFence;
   for (const line of readme.split('\n')) {
-    if (line.trim().startsWith('```')) {
-      inCodeBlock = !inCodeBlock;
+    const fenceMatch = /^\s*(`{3,}|~{3,})/.exec(line);
+    if (codeFence) {
+      const fenceCharacter = codeFence[0];
+      const closingFence = new RegExp(
+        `^\\s*${fenceCharacter}{${codeFence.length},}\\s*$`,
+      );
+      if (closingFence.test(line)) codeFence = undefined;
       continue;
     }
-    if (inCodeBlock) continue;
+    if (fenceMatch) {
+      codeFence = fenceMatch[1];
+      continue;
+    }
     const match = /^(#{2,6})\s+(.+)$/.exec(line);
     if (!match) continue;
     const text = match[2]

--- a/scripts/verify-readme-contract.mjs
+++ b/scripts/verify-readme-contract.mjs
@@ -132,7 +132,7 @@ const fail = (message) => {
  * following the editor's use of `lastIndexOfRegex` for the start token.
  */
 const guard = '(^|[^`\\\\])';
-const sectionFrom = (source, name) => {
+const sectionFrom = (source, name, trim = true) => {
   const starts = [...source.matchAll(new RegExp(`${guard}<!--\\s+start\\s+${name}\\s+-->`, 'g'))];
   if (starts.length === 0) return null;
   const last = starts.at(-1);
@@ -141,7 +141,9 @@ const sectionFrom = (source, name) => {
     ...source.slice(from).matchAll(new RegExp(`${guard}<!--\\s+end\\s+${name}\\s+-->`, 'g')),
   ];
   const end = ends.at(-1);
-  return end ? source.slice(from, from + end.index).trim() : null;
+  if (!end) return null;
+  const body = source.slice(from, from + end.index);
+  return trim ? body.trim() : body;
 };
 
 const section = (name) => sectionFrom(readme, name);
@@ -322,6 +324,18 @@ if (usage === null) {
           candidate !== null && typeof candidate === 'object' && 'uses' in candidate
             ? candidate
             : null;
+        if (step !== null) {
+          const expectedStepKeys = ['uses', 'with'];
+          const stepKeys = Object.keys(step);
+          const hasExactStepKeys =
+            stepKeys.length === expectedStepKeys.length &&
+            expectedStepKeys.every((key) => Object.hasOwn(step, key));
+          if (!hasExactStepKeys) {
+            fail(
+              `the usage step properties do not match the generator — want ${expectedStepKeys.join(', ')}, got ${stepKeys.join(', ') || 'none'}`,
+            );
+          }
+        }
       }
     } catch (error) {
       fail(`the usage block is not parseable yaml: ${error.message}`);
@@ -456,6 +470,10 @@ const tableSection = async (name, declared, expectedCells) => {
     return;
   }
   const tableRows = body.split('\n').filter((line) => line.trim().startsWith('|'));
+  if (keys.length > 0 && tableRows.length !== body.split('\n').length) {
+    fail(`the ${name} section carries content outside the generated table`);
+    return;
+  }
   if (tableRows.length > 0) {
     const header = cells(tableRows[0]);
     const delimiter = tableRows.length > 1 ? cells(tableRows[1]) : [];
@@ -651,6 +669,147 @@ for (const name of ['title', 'description', 'branding']) {
     ok(`the ${name} section carries the action's ${name} from action.yml`);
   } else {
     fail(`the ${name} section does not exactly project action.yml; section reads ${JSON.stringify(actual)}`);
+  }
+}
+
+/** Mirrors the contents projection in `src/sections/update-contents.ts`. */
+const expectedContents = async () => {
+  const headers = [];
+  let inCodeBlock = false;
+  for (const line of readme.split('\n')) {
+    if (line.trim().startsWith('```')) {
+      inCodeBlock = !inCodeBlock;
+      continue;
+    }
+    if (inCodeBlock) continue;
+    const match = /^(#{2,6})\s+(.+)$/.exec(line);
+    if (!match) continue;
+    const text = match[2]
+      .trim()
+      .replaceAll(/<img[^>]*>/g, '')
+      .trim()
+      .replaceAll(/\[([^\]]+)]\([^)]+\)/g, '$1');
+    if (text && !text.toLowerCase().includes('contents')) {
+      headers.push({ level: match[1].length, text });
+    }
+  }
+  if (headers.length === 0) return '';
+
+  const minimumLevel = Math.min(...headers.map(({ level }) => level));
+  const anchorCounts = new Map();
+  const lines = ['## Table of Contents', ''];
+  for (const { level, text } of headers) {
+    const baseAnchor = text
+      .toLowerCase()
+      .replaceAll(/[^\w\s-]/g, '')
+      .replaceAll(/\s+/g, '-')
+      .replaceAll(/-+/g, '-')
+      .replaceAll(/^-|-$/g, '');
+    const count = anchorCounts.get(baseAnchor) ?? 0;
+    anchorCounts.set(baseAnchor, count + 1);
+    const anchor = count === 0 ? baseAnchor : `${baseAnchor}-${count}`;
+    lines.push(`${'  '.repeat(level - minimumLevel)}- [${text}](#${anchor})`);
+  }
+  return generatedMarkdown(lines.join('\n'));
+};
+
+const contents = section('contents');
+if (contents === null) {
+  skip('no contents section markers in this README, skipping');
+} else {
+  const actual = await generatedMarkdown(contents);
+  const expected = await expectedContents();
+  if (actual === expected) {
+    ok('the contents section exactly indexes the generated README headings');
+  } else {
+    fail(
+      `the contents section does not exactly project the generated README headings — want ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`,
+    );
+  }
+}
+
+/** Mirrors HTML attribute escaping and badge composition in `update-badges.ts`. */
+const escapeAttribute = (value) =>
+  String(value)
+    .replaceAll('&', '&amp;')
+    .replaceAll('"', '&quot;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;');
+
+const expectedBadges = async (owner, repo) => {
+  const repositoryUrl = `https://github.com/${owner}/${repo}`;
+  const badges = [
+    {
+      img: `https://img.shields.io/github/v/release/${owner}/${repo}?display_name=tag&sort=semver&logo=github&style=flat-square`,
+      alt: 'Release by tag',
+      url: `${repositoryUrl}/releases/latest`,
+    },
+    {
+      img: `https://img.shields.io/github/release-date/${owner}/${repo}?display_name=tag&sort=semver&logo=github&style=flat-square`,
+      alt: 'Release by date',
+      url: `${repositoryUrl}/releases/latest`,
+    },
+    {
+      img: `https://img.shields.io/github/last-commit/${owner}/${repo}?logo=github&style=flat-square`,
+      alt: 'Commit',
+    },
+    {
+      img: `https://img.shields.io/github/issues/${owner}/${repo}?logo=github&style=flat-square`,
+      alt: 'Open Issues',
+      url: `${repositoryUrl}/issues`,
+    },
+    {
+      img: `https://img.shields.io/github/downloads/${owner}/${repo}/total?logo=github&style=flat-square`,
+      alt: 'Downloads',
+    },
+  ];
+  const markup = badges
+    .map((badge) => {
+      const image = `<img src="${escapeAttribute(badge.img)}" alt="${escapeAttribute(badge.alt)}" />`;
+      return badge.url ? `<a href="${escapeAttribute(badge.url)}">${image}</a>` : image;
+    })
+    .join('');
+  return generatedMarkdown(markup);
+};
+
+const badges = section('badges');
+if (badges === null) {
+  skip('no badges section markers in this README, skipping');
+} else {
+  const badgeSetting = config.versioning?.badge ?? true;
+  if (!badgeSetting) {
+    const originalBadges =
+      originalReadme === null ? null : sectionFrom(originalReadme, 'badges', prettierEnabled);
+    const generatedBadges = sectionFrom(readme, 'badges', prettierEnabled);
+    if (originalBadges === null) {
+      skip('badges are disabled and no original badges projection is available');
+    } else if (
+      generatedBadges !== null &&
+      (prettierEnabled
+        ? (await generatedMarkdown(generatedBadges)) === (await generatedMarkdown(originalBadges))
+        : generatedBadges === originalBadges)
+    ) {
+      ok('the disabled badges section preserves its original content');
+    } else {
+      fail('the disabled badges section does not preserve its original content');
+    }
+  } else {
+    const [repositoryOwner, repositoryName] = String(expectedRepository ?? '').split('/');
+    const owner = config.owner ?? repositoryOwner;
+    const repo = config.repo ?? repositoryName;
+    if (!owner || !repo) {
+      fail('the badges projection cannot resolve the generated repository owner and name');
+    } else {
+      const actual = await generatedMarkdown(badges);
+      const expected = await expectedBadges(owner, repo);
+      if (actual === expected) {
+        ok('the badges section exactly projects the generated repository badges');
+      } else {
+        fail(
+          `the badges section does not exactly project the generated repository badges — want ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`,
+        );
+      }
+    }
   }
 }
 

--- a/src/sections/update-contents.ts
+++ b/src/sections/update-contents.ts
@@ -30,17 +30,20 @@ function headerToAnchor(text: string): string {
 function extractHeaders(content: string): { level: number; text: string }[] {
   const headers: { level: number; text: string }[] = [];
   const lines = content.split('\n');
-  let inCodeBlock = false;
+  let codeFence: string | undefined;
 
   for (const line of lines) {
-    // Track code block state
-    if (line.trim().startsWith('```')) {
-      inCodeBlock = !inCodeBlock;
+    const fenceMatch = /^\s*(`{3,}|~{3,})/.exec(line);
+    if (codeFence) {
+      const fenceCharacter = codeFence[0];
+      const closingFence = new RegExp(`^\\s*${fenceCharacter}{${codeFence.length},}\\s*$`);
+      if (closingFence.test(line)) {
+        codeFence = undefined;
+      }
       continue;
     }
-
-    // Skip if inside code block
-    if (inCodeBlock) {
+    if (fenceMatch) {
+      codeFence = fenceMatch[1];
       continue;
     }
 


### PR DESCRIPTION
## What changed

- Require generated usage steps to contain exactly the `uses` and `with` properties.
- Reject prose, comments, and blank lines outside nonempty generated input/output tables.
- Validate complete contents and enabled-badge projections.
- Preserve disabled badge spans byte-for-byte when formatting is off, and formatter-equivalently when formatting is on.
- Add a three-pass generator-to-verifier integration regression.

## Why

A formal Codex review submitted on the final head of #634 identified three valid gaps after that PR had already merged. Stable stale content could therefore pass the real-repository contract gate for usage, tables, contents, or badges.

## User impact

The real-repository integration gate now proves every opted-in generated section matches what users receive, so a stable no-op or partial updater cannot be certified merely because generation converges.

## Validation

- Independent adversarial checker: satisfied
- Focused verifier and integration suites pass
- Full test suite passes
- Vite+ format, lint, and type checks pass
- Markdown lint passes

Follow-up to #634 formal review comments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved README contract validation for usage steps, tables, contents, and badges.
  * Added checks for duplicate headings, invalid badge configurations, repository links, and HTML escaping.
  * Preserved user-managed disabled badge sections, including formatting variations.

* **Tests**
  * Added integration coverage for multi-pass README generation and external verification.
  * Added regression tests for invalid README content and badge behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->